### PR TITLE
[Issue #15] Uses stdlib ensure_packages to avoid duplicate declaration errors

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -1,3 +1,5 @@
 fixtures:
+  repositories:
+    stdlib: "git://github.com/puppetlabs/puppetlabs-stdlib.git"
   symlinks:
     make: "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,7 +9,6 @@ class make (
 
   # "package" will validate $package_ensure for us..
 
-  package { $package_name:
-    ensure => $package_ensure,
-  }
+  ensure_packages($package_name, {'ensure' => $package_ensure})
+
 }

--- a/metadata.json
+++ b/metadata.json
@@ -16,8 +16,8 @@
   ],
   "dependencies": [
     {
-      "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.16.0"
+      "name": "puppetlabs/stdlib",
+      "version_requirement": ">= 4.16.0 < 5.0.0"
     }
   ],
   "operatingsystem_support": [

--- a/metadata.json
+++ b/metadata.json
@@ -15,7 +15,10 @@
     }
   ],
   "dependencies": [
-
+    {
+      "name": "puppetlabs-stdlib",
+      "version_requirement": ">= 4.16.0"
+    }
   ],
   "operatingsystem_support": [
     {


### PR DESCRIPTION
Avoids duplicate declaration errors in case package 'make' is managed in other modules in the same node.

> Will still error if 'ensure' is not identical in all declarations